### PR TITLE
feat: Add design tokens for primitives and company branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Design System React</title>
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,10 @@ body {
 ul {
   list-style: none;
 }
+
+body {
+  background-color: var(--cb-color-surface-bg);
+  /** add temporary width and height to see the theming. Remove after testing **/
+  width: 100vw;
+  height: 100vh;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -7,15 +7,12 @@
 
 body {
   font-family: Arial, sans-serif;
-}
-
-ul {
-  list-style: none;
-}
-
-body {
   background-color: var(--cb-color-surface-bg);
   /** add temporary width and height to see the theming. Remove after testing **/
   width: 100vw;
   height: 100vh;
+}
+
+ul {
+  list-style: none;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,8 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
+import "./ui-kit/tokens/primitives.css";
+import "./ui-kit/tokens/my-company-brand.css";
+import "./index.css";
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(

--- a/src/ui-kit/tokens/my-company-brand.css
+++ b/src/ui-kit/tokens/my-company-brand.css
@@ -1,0 +1,11 @@
+:root {
+    --cb-color-surface-bg: var(--cb-color-neutrals-white);
+    --cb-color-surface-primary: var(--cb-color-brand-orange);
+    /* ... */
+    --cb-color-text-primary: var(--cb-color-neutrals-black);
+    /* ... completar con el resto de tokens de color del branding siguiendo su estructura de grupos y subgrupos */
+    --cb-elevation-none: 0;
+    --cb-elevation-sm: 0px 2px 2px 0px rgba(0, 0, 0, 0.1), 0px 3px 1px -2px rgba(0, 0, 0, 0.05),
+      0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+    /* ... completar con el resto de tokens de la marca*/
+  }

--- a/src/ui-kit/tokens/my-company-brand.css
+++ b/src/ui-kit/tokens/my-company-brand.css
@@ -1,11 +1,65 @@
 :root {
+
+    /* font */
+    --cb-font-size-body--xs: 14px;
+    --cb-font-size-body--sm: 16px;
+    --cb-font-size-body--md: 18px;
+    --cb-font-size-body--lg: 22px;
+    --cb-font-size-subtitle--xs: 32px;
+    --cb-font-size-subtitle--md: 40px;
+    --cb-font-size-subtitle--lg: 48px;
+    --cb-font-size-page-title: 61px;
+    --cb-font-family-body: Inter;
+    --cb-font-family-title: Inter;
+
+
+    /* surface */
     --cb-color-surface-bg: var(--cb-color-neutrals-white);
+    --cb-color-surface-disabled: var(--cb-color-neutrals-100);
+    --cb-color-surface-success: var(--cb-color-green-400);
+    --cb-color-surface-danger: var(--cb-color-red-400);
     --cb-color-surface-primary: var(--cb-color-brand-orange);
-    /* ... */
+    --cb-color-surface-secondary: var(--cb-color-orange-100);
+    --cb-color-surface-primary_hover: var(--cb-color-orange-600);
+
+
+    /* border */
+    --cb-color-border-focused: var(--cb-color-brand-orange);
+    --cb-color-border-sucess: var(--cb-color-green-400);
+    --cb-color-border-error: var(--cb-color-red-400);
+    --cb-color-border-primary: var(--cb-color-neutrals-200);
+
+    /* icon */
+    --cb-color-icon-primary: var(--cb-color-neutrals-black);
+    --cb-color-icon-invert: var(--cb-color-neutrals-white);
+
+    /* text */
+    --cb-color-text-secondary: var(--cb-color-neutrals-600);
+    --cb-color-text-invert: var(--cb-color-neutrals-white);
     --cb-color-text-primary: var(--cb-color-neutrals-black);
-    /* ... completar con el resto de tokens de color del branding siguiendo su estructura de grupos y subgrupos */
+
+    /* spacing */
+    --cb-spacing-xxs: 4px;
+    --cb-spacing-xs: 8px;
+    --cb-spacing-sm: 16px;
+    --cb-spacing-md: 12px;
+    --cb-spacing-lg: 24px;
+    --cb-spacing-xl: 32px;
+
+    /* elevation */
     --cb-elevation-none: 0;
-    --cb-elevation-sm: 0px 2px 2px 0px rgba(0, 0, 0, 0.1), 0px 3px 1px -2px rgba(0, 0, 0, 0.05),
-      0px 1px 5px 0px rgba(0, 0, 0, 0.12);
-    /* ... completar con el resto de tokens de la marca*/
+    --cb-elevation-sm: 0px 2px 2px 0px rgba(0,0,0,0.10), 0px 3px 1px -2px rgba(0,0,0,0.05), 0px 1px 5px 0px rgba(0,0,0,0.12);
+    --cb-elevation-md: 0px 8px 20px 1px rgba(0,0,0,0.05), 0px 3px 14px 5px rgba(0,0,0,0.05), 0px 5px 10px -5px rgba(0,0,0,0.03);
+    --cb-elevation-lg: 0px 16px 20px 2px rgba(0,0,0,0.05), 0px 6px 20px 3px rgba(0,0,0,0.05), 0px 16px 14px -5px rgba(0,0,0,0.03);
+    
+    /* border */
+    --cb-border-width-none: 0px;
+    --cb-border-width-sm: 1px;
+    --cb-border-width-md: 2px;
+    --cb-border-width-lg: 4px;
+    --cb-border-radius-none: 0px;
+    --cb-border-radius-sm: 4px;
+    --cb-border-radius-md: 8px;
+    --cb-border-radius-lg: 16px;
+    --cb-border-radius-circle: 50%;
   }

--- a/src/ui-kit/tokens/primitives.css
+++ b/src/ui-kit/tokens/primitives.css
@@ -1,0 +1,11 @@
+:root {
+    --cb-color-orange-600: #cd4108;
+    --cb-color-orange-700: #b12e00;
+    --cb-color-orange-800: #912100;
+    --cb-color-grey-800: #2c3341;
+    --cb-color-brand-orange: #ed5c25;
+    --cb-color-neutrals-white: #ffffff;
+    --cb-color-neutrals-black: #000000;
+    --cb-color-neutrals-50: #e3e3e3;
+    /* ... completar con el resto de primitivos siguiendo su estructura de grupos y subgrupos */
+  }

--- a/src/ui-kit/tokens/primitives.css
+++ b/src/ui-kit/tokens/primitives.css
@@ -1,11 +1,56 @@
 :root {
-    --cb-color-orange-600: #cd4108;
-    --cb-color-orange-700: #b12e00;
+    /* Orange */
+    --cb-color-orange-50: #FFEFE6;
+    --cb-color-orange-100: #FFCEB6;
+    --cb-color-orange-200: #FFAE89;
+    --cb-color-orange-300: #FF9062;
+    --cb-color-orange-400: ;
+    --cb-color-orange-500: ;
+    --cb-color-orange-600: #CD4108;
+    --cb-color-orange-700: #B12E00;
     --cb-color-orange-800: #912100;
-    --cb-color-grey-800: #2c3341;
+    --cb-color-orange-900: #5B1F15;
+
+    /* Brand */
+    --cb-color-brand-purple: #945CCC;
+    --cb-color-brand-yellow: #FCB813;
     --cb-color-brand-orange: #ed5c25;
+    --cb-color-brand-blue: #111C4E;
+
+    /* Grey */
+    --cb-color-grey-white: #FFFFFF;
+    --cb-color-grey-200: #B8BECA;
+    --cb-color-grey-300: #9DA5B4;
+    --cb-color-grey-400: #848C9E;
+    --cb-color-grey-500: #6B7587;
+    --cb-color-grey-600: #555E70;
+    --cb-color-grey-700: #404858;
+    --cb-color-grey-800: #2C3341;
+
+    /* Green */
+    --cb-color-green-400: #198754;
+    --cb-color-green-900: #051B11;
+
+    /* Yellow */
+    --cb-color-yellow-400: #FFC107;
+    --cb-color-yellow-900: #332701;
+
+    /* Red */
+    --cb-color-red-400: #DC3545;
+    --cb-color-red-900: #3E0E10;
+
+    /* Neutrals */
     --cb-color-neutrals-white: #ffffff;
-    --cb-color-neutrals-black: #000000;
     --cb-color-neutrals-50: #e3e3e3;
-    /* ... completar con el resto de primitivos siguiendo su estructura de grupos y subgrupos */
+    --cb-color-neutrals-100: #CCCCCC;
+    --cb-color-neutrals-200: #B6B6B6;
+    --cb-color-neutrals-300: #A1A1A1;
+    --cb-color-neutrals-400: #8C8C8C;
+    --cb-color-neutrals-500: #777777;
+    --cb-color-neutrals-600: #636363;
+    --cb-color-neutrals-700: #505050;
+    --cb-color-neutrals-800: #3E3E3E;
+    --cb-color-neutrals-900: #2C2C2C;
+    --cb-color-neutrals-black: #000000;
+   
   }


### PR DESCRIPTION
- Created  to define foundational design tokens (e.g., colors, neutrals) that are context-independent.
- Created  to define brand-specific tokens, including colors, typography, spacing, and elevations.
- Structured tokens using a clear and consistent naming convention to support branding and theming.
- Added support for dark mode using  media query in .
- Imported design tokens into  to ensure global availability.
- Updated  to test tokens by setting the body background color based on the design system's surface background token.