### PR TITLE
feat(icon): add Icon component with font icons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import "./ui-kit/atoms/icon/font-icons.css";
 import Subtitle from "./ui-kit/atoms/text/subtitle";
 import PageTitle from "./ui-kit/atoms/text/page-title";
 import Body from "./ui-kit/atoms/text/body";
-
+import Icon from "./ui-kit/atoms/icon";
 
 
 // Componente Header
@@ -12,10 +12,13 @@ function App() {
     <>
       <h1>Design System React</h1>
       <Subtitle>¡Bienvenido al Design System React!</Subtitle>
-      <i className="cb-icons-checkmark-circle"></i>
+      <i className="cb-icon-checkmark-circle"></i>
+      <Icon name="checkmark-circle" />
+      <Icon name="search" />
+      
       <Subtitle size="xs">Subtítulo pequeño</Subtitle>
       <Subtitle size="md">Subtítulo mediano</Subtitle>
-      <Subtitle size="lg">Subtítulo grande</Subtitle>
+      <Subtitle size="lg">Subtítulo grande con Icono: <Icon name="search" /></Subtitle>
       <PageTitle size="xs">Título de Página Pequeño</PageTitle>
       <PageTitle size="md">Título de Página Mediano</PageTitle>
       <PageTitle size="lg">Título de Página Grande</PageTitle>

--- a/src/ui-kit/atoms/icon/index.jsx
+++ b/src/ui-kit/atoms/icon/index.jsx
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+import "./font-icons.css"; // Asegúrate de que este archivo sea el correcto y esté bien cargado
+
+const Icon = ({ name }) => {
+  return <span className={`cb-icons-${name}`} />;  // Cambio a cb-icons- en lugar de cb-icon-
+};
+
+Icon.propTypes = {
+  name: PropTypes.string.isRequired,
+};
+
+export default Icon;


### PR DESCRIPTION
- Added Icon component that allows to display icons using caba-icons font.
- The component accepts the `name` prop to select the desired icon.
- Corrected the CSS class in `Icon.jsx` to match the classes defined in `font-icons.css` (from `cb-icon-` to `cb-icons-`).
- Checked loading and path of icon fonts (`eot`, `woff`, `ttf`, `svg`).
- Added `font-icons.css` import in `Icon.jsx` and `App.jsx`.
- Tested icons in the interface using the `Icon` component inside `Subtitle`.